### PR TITLE
Fix for byte-compile warnings

### DIFF
--- a/coverlay.el
+++ b/coverlay.el
@@ -72,7 +72,7 @@
   (with-current-buffer (get-buffer-create coverlay:data-buffer-name)
     (erase-buffer)
     (insert-file-contents data-file-path)
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (current-buffer)))
 
 (defun coverlay-create-stats-alist-from-buffer (buf)
@@ -194,7 +194,7 @@
 
 (defun coverlay-overlay-current-buffer-with-list (tuple-list)
   (save-excursion
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (dolist (ovl (coverlay-map-overlays tuple-list))
       (progn
         (overlay-put ovl 'face (cons 'background-color coverlay:untested-line-background-color))


### PR DESCRIPTION
I got following byte-compile warnings with origin code.

```
In coverlay-create-stats-buffer:
coverlay.el:74:27:Warning: `beginning-of-buffer' is for interactive use only;
    use `(goto-char (point-min))' instead.

In coverlay-overlay-current-buffer-with-list:
coverlay.el:195:51:Warning: `beginning-of-buffer' is for interactive use only;
    use `(goto-char (point-min))' instead.
```
