### PR TITLE
Use define-obsolete-*-alias instead of make-obsolete*

### DIFF
--- a/coverlay.el
+++ b/coverlay.el
@@ -578,9 +578,9 @@
   :require 'coverlay)
 
 ;;;###autoload
-(make-obsolete 'coverlay-mode #'global-coverlay-mode "3.0.0")
+(define-obsolete-function-alias 'coverlay-mode #'global-coverlay-mode "3.0.0")
 ;;;###autoload
-(make-obsolete-variable 'coverlay-mode-hook 'coverlay-minor-mode-hook "3.0.0")
+(define-obsolete-variable-alias 'coverlay-mode-hook 'coverlay-minor-mode-hook "3.0.0")
 
 (defun coverlay--switch-mode (enabled)
   "Switch global mode to be ENABLED or not."


### PR DESCRIPTION
refs #11 

Instead of simply marking them as obsolete, define an aliases.  It was my mistake in ca1e92e25523cac21b1e4e61a2657a443a7e71ad .